### PR TITLE
Remove response types for now

### DIFF
--- a/Api/Response types.md
+++ b/Api/Response types.md
@@ -1,2 +1,0 @@
-## Response types
-


### PR DESCRIPTION
We should standardize response types (WIP) before we document them